### PR TITLE
Code of Conduct Update Based on PR Feedbacks.

### DIFF
--- a/CodeOfConduct.md
+++ b/CodeOfConduct.md
@@ -24,7 +24,7 @@ All team members agree to:
 - All commits must have **meaningful commit messages** following the agreed format.
 
 ## Code Reviews
-- All pull requests must be reviewed by **at least three team members** before merging into the develop or main branches.
+- All pull requests must be reviewed by **at least two team members** before merging into the develop or main branches.
 - For small or urgent changes, a minimum of **two approvals** may be acceptable if agreed by the Scrum Master.
 - This ensures higher code quality, shared knowledge of changes, and reduces the risk of bugs reaching production.
 


### PR DESCRIPTION
- Making the reviewers only two people. 
- Updating the sharing of the update timeline by team members.
- Removing the hotfix branch from the code of conduct.
- Added Technical Standards