### PR TITLE
use only develop badge for code coverage due to the branching strategy we are following (git workflow)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -8,26 +8,23 @@
 
 ---
 
+### Code Coverage
+
+[![codecov](https://codecov.io/github/rzerradnapier/devops-project/branch/develop/graph/badge.svg?token=S2GDMKVOKK)](https://codecov.io/github/rzerradnapier/devops-project)
+
+---
+
 ### Develop branch
 
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/rzerradnapier/devops-project/main.yml?branch=develop)
-
-[![codecov](https://codecov.io/github/rzerradnapier/devops-project/branch/develop/graph/badge.svg?token=S2GDMKVOKK)](https://codecov.io/github/rzerradnapier/devops-project)
 
 ### Release branch
 
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/rzerradnapier/devops-project/main.yml?branch=release)
 
-[![codecov](https://codecov.io/github/rzerradnapier/devops-project/branch/release/graph/badge.svg?token=S2GDMKVOKK)](https://codecov.io/github/rzerradnapier/devops-project)
-
-
 ### Master branch
 
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/rzerradnapier/devops-project/main.yml?branch=master)
-
-[![codecov](https://codecov.io/github/rzerradnapier/devops-project/branch/master/graph/badge.svg?token=S2GDMKVOKK)](https://codecov.io/github/rzerradnapier/devops-project)
-
-
 
 ---
 


### PR DESCRIPTION
use only develop badge for code coverage due to the branching strategy we are following (git workflow)